### PR TITLE
when form_for is used with custom builder don't expect association_name

### DIFF
--- a/releaf-core/app/helpers/releaf/builders/form_builder.rb
+++ b/releaf-core/app/helpers/releaf/builders/form_builder.rb
@@ -13,7 +13,7 @@ class Releaf::Builders::FormBuilder < ActionView::Helpers::FormBuilder
 
     builder = self
     until builder.options[:parent_builder].nil? do
-      parts << builder.options[:relation_name]
+      parts << builder.options[:relation_name] if builder.options[:relation_name]
       builder = builder.options[:parent_builder]
     end
 


### PR DESCRIPTION
when form_for is used with custom builder don't expect association_name to be passed as option

This way you can use:

```ruby
  f.form_for :books, builder: Books::FormBuilder do |ff|
    ff.title
```

and in Books::FormBuilder you can create method #render_title (no
association in between render and title parts).
This allows you to reuse form builder to render single book for example,
or simply split form builder into many smaller form builders.