### PR TITLE
Change fill_in_richtext test helper to be more like fill_in

### DIFF
--- a/releaf-content/spec/features/nodes_spec.rb
+++ b/releaf-content/spec/features/nodes_spec.rb
@@ -179,7 +179,7 @@ describe "Nodes", js: true, with_tree: true, with_root: true do
 
       fill_in 'Name', with: child_text
       fill_in "Slug", with: child_text
-      fill_in_richtext 'resource_content_attributes_text_html', child_text
+      fill_in_richtext 'Text', with: child_text
       if position
         select position, from: 'Item position'
       end

--- a/releaf-core/spec/features/edit_actions_spec.rb
+++ b/releaf-core/spec/features/edit_actions_spec.rb
@@ -75,7 +75,7 @@ feature "Base controller edit", js: true do
       expect(page).to have_css('.remove-nested-item')
       fill_in 'resource_chapters_attributes_0_title', with: 'Chapter 1'
       fill_in 'resource_chapters_attributes_0_text', with: 'todo'
-      fill_in_richtext 'resource_chapters_attributes_0_sample_html', "xx"
+      fill_in_richtext 'Sample', with: "xx"
     end
 
     expect(page).to_not have_css('.remove-nested-item')
@@ -97,7 +97,7 @@ feature "Base controller edit", js: true do
 
         fill_in "Title", with: "Chapter 1"
         fill_in "Text", with: "some text"
-        fill_in_richtext 'resource_chapters_attributes_0_sample_html', "xx"
+        fill_in_richtext 'Sample', with: "xx"
       end
     end
 

--- a/releaf-core/spec/features/richtext_spec.rb
+++ b/releaf-core/spec/features/richtext_spec.rb
@@ -6,14 +6,14 @@ feature "Richtext editing", js: true do
 
   scenario "Image toolbar available when controller support attachments" do
     visit new_releaf_content_node_path(content_type: 'TextPage')
-    fill_in_richtext 'resource_content_attributes_text_html', "some text"
+    fill_in_richtext 'Text', with: "some text"
     expect(page).to have_css("a.cke_button__image")
   end
 
   scenario "Image toolbar unavailable when controller doesn't support attachments" do
     allow_any_instance_of(Admin::BooksController).to receive(:releaf_richtext_attachment_upload_url).and_return("")
     visit new_admin_book_path
-    fill_in_richtext 'resource_summary_html', "some text"
+    fill_in_richtext "Summary", with: "some text"
     expect(page).to_not have_css("a.cke_button__image")
   end
 end


### PR DESCRIPTION
1) use the with: "text" syntax as in fill_in
2) locate the field by using either the id or the label text, same as fill_in