### PR TITLE
Document delegated methods

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,9 +1,7 @@
 --title "Releaf documentation"
 --protected
 --output-dir api
-# WORKAROUND for: https://github.com/lsegal/yard/issues/825
---legacy
-
+--plugin activerecord
 
 releaf-permissions/app/**/*.rb
 releaf-permissions/lib/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,9 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 end
+
+group :documentation do
+  gem 'yard'
+  gem 'github-markdown', '>= 0.5.3'
+  gem 'redcarpet', '>= 2.2.2'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,5 @@ group :documentation do
   gem 'yard'
   gem 'github-markdown', '>= 0.5.3'
   gem 'redcarpet', '>= 2.2.2'
+  gem 'yard-activerecord', '~> 0.0.14'
 end


### PR DESCRIPTION
This helps developer to simply run yardoc to generate api documentation without manually installing gems.