### PR TITLE
Releaf::Search written in arel

### DIFF
--- a/releaf-core/spec/features/search_spec.rb
+++ b/releaf-core/spec/features/search_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
 
 describe Releaf::Search do
-
-  with_model :Profile do
+  with_model :Profile, scope: :all do
     table do |t|
       t.string :real_name
       t.integer :author_id
@@ -10,7 +9,7 @@ describe Releaf::Search do
 
   end
 
-  with_model :Author do
+  with_model :Author, scope: :all do
     table  do |t|
       t.string :name
     end
@@ -23,7 +22,7 @@ describe Releaf::Search do
     end
   end
 
-  with_model :BlogPost do
+  with_model :BlogPost, scope: :all do
     table do |t|
       t.string :title
       t.text :description
@@ -40,7 +39,7 @@ describe Releaf::Search do
     end
   end
 
-  with_model :Comment do
+  with_model :Comment, scope: :all do
     table do |t|
       t.string :text
       t.belongs_to :blog_post
@@ -54,7 +53,7 @@ describe Releaf::Search do
     end
   end
 
-  with_model :CommentAuthor do
+  with_model :CommentAuthor, scope: :all do
     table do |t|
       t.string :name
       t.timestamps(null: true)
@@ -65,174 +64,220 @@ describe Releaf::Search do
     end
   end
 
-  describe "searching" do
-    it "escapes search text" do
-      mysql_expected_result = /LIKE LOWER\('%SQL\\\'injection%'\)/
-      postgresql_expected_result = /LIKE LOWER\('%SQL''injection%'\)/
-      expected_results = ENV['RELEAF_DB'] == 'postgresql' ? postgresql_expected_result : mysql_expected_result
+  before(:all) do
+    @profile1 = Profile.create!(real_name: 'unknown')
+    @profile2 = Profile.create!(real_name: 'classified')
 
-      params = {
-        text: "SQL'injection",
-        relation: BlogPost.all,
-        fields: [:title]
-      }
-      expect( described_class.prepare(params).to_sql ).to match(expected_results)
-    end
+    @post_author1 = Author.create!(name: 'author1', profile: @profile1)
+    @post_author2 = Author.create!(name: 'author2', profile: @profile2)
 
-    it "supports searches by multiple words" do
-      DatabaseCleaner.clean # hack due to this https://github.com/Casecommons/with_model/pull/18 (nested transactions)
+    @post1 = BlogPost.create!(title: "sick dog", author: @post_author1)
+    @post2 = BlogPost.create!(title: "sick bird", author: @post_author1, editor: @post_author1)
+    @post3 = BlogPost.create!(title: "sick horse", author: @post_author2, editor: @post_author1)
+    @post4 = BlogPost.create!(title: "healty")
+    @post5 = BlogPost.create!(title: "sick horse that died", author: @post_author1, deleted: true)
 
-      BlogPost.create!(title: "sick dog")
-      post = BlogPost.create!(title: "sick and big dog and heavy")
+    @comment_author1 = CommentAuthor.create!(name: "Paul")
+    @comment_author2 = CommentAuthor.create!(name: "John")
 
-      params = {
-        text: "heavy sick dog",
-        relation: BlogPost.all,
-        fields: [:title]
-      }
-      expect( described_class.prepare(params).to_a ).to eq([post])
+    @comment1 = Comment.create!(text: "big and heavy", comment_author: @comment_author1, blog_post: @post1)
+    @comment2 = Comment.create!(text: "big and wide", comment_author: @comment_author1, blog_post: @post1)
+    @comment3 = Comment.create!(text: "big", comment_author: @comment_author2, blog_post: @post2)
+    @comment4 = Comment.create!(text: "small", comment_author: @comment_author2, blog_post: @post2)
+    @comment5 = Comment.create!(text: "big", comment_author: @comment_author2, blog_post: @post3)
+    @comment6 = Comment.create!(text: "small", comment_author: @comment_author2, blog_post: @post4)
+  end
 
-      BlogPost.delete_all # hack
-    end
+  it "escapes search text" do
+    mysql_expected_result = /LIKE LOWER\('%SQL\\\'injection%'\)/
+    postgresql_expected_result = /LIKE LOWER\('%SQL''injection%'\)/
+    expected_results = ENV['RELEAF_DB'] == 'postgresql' ? postgresql_expected_result : mysql_expected_result
 
-    it "searches with LIKE %text% statement" do
-      DatabaseCleaner.clean # hack due to this https://github.com/Casecommons/with_model/pull/18 (nested transactions)
+    params = {
+      text: "SQL'injection",
+      relation: BlogPost,
+      fields: [:title]
+    }
+    expect( described_class.prepare(params).to_sql ).to match(expected_results)
+  end
 
-      BlogPost.create!(title: "internatio nalization")
-      post = BlogPost.create!(title: "internationalization")
+  it "supports searches by multiple words" do
+    params = {
+      text: "died sick",
+      relation: BlogPost,
+      fields: [:title]
+    }
+    expect( described_class.prepare(params).to_a ).to eq([@post5])
+  end
 
-      params = {
-        text: "national",
-        relation: BlogPost.all,
-        fields: [:title]
-      }
-      expect( described_class.prepare(params).to_a ).to eq([post])
+  it "searches with LIKE %text% statement" do
+    params = {
+      text: "thor",
+      relation: Author,
+      fields: [:name]
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author1, @post_author2])
 
-      BlogPost.delete_all # hack
-    end
+    params[:text] = 'thor2'
+    expect( described_class.prepare(params) ).to match_array([@post_author2])
+  end
 
-    it "supports search by nested fields" do
-      DatabaseCleaner.clean # hack due to this https://github.com/Casecommons/with_model/pull/18 (nested transactions)
+  it "supports searching in base model columns" do
+    params = {
+      relation: Author,
+      fields: [:name],
+      text: 'author1'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author1])
+  end
 
-      profile1 = Profile.create!(real_name: 'unknown')
-      profile2 = Profile.create!(real_name: 'classified')
+  it "supports searching in nested association columns" do
+    params = {
+      relation: Author,
+      fields: [{blog_posts: [:title]}],
+      text: 'bird'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author1])
+  end
 
-      post_author1 = Author.create!(name: 'author1', profile: profile1)
-      post_author2 = Author.create!(name: 'author2', profile: profile2)
+  it "supports searching in belongs_to association columns" do
+    params = {
+      relation: BlogPost,
+      fields: [{author: [:name]}],
+      text: 'author2'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post3])
+  end
 
-      post1 = BlogPost.create!(title: "sick dog", author: post_author1)
-      post2 = BlogPost.create!(title: "sick bird", author: post_author1, editor: post_author1)
-      post3 = BlogPost.create!(title: "sick horse", author: post_author2, editor: post_author1)
-      post4 = BlogPost.create!(title: "healty")
+  it "supports searching in has_one association columns" do
+    params = {
+      relation: Author,
+      fields: [{profile: [:real_name]}],
+      text: 'classified'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author2])
+  end
 
-      comment_author1 = CommentAuthor.create!(name: "Paul")
-      comment_author2 = CommentAuthor.create!(name: "John")
+  it "supports searching in has_many association columns" do
+    params = {
+      relation: Author,
+      fields: [{blog_posts: [:title]}],
+      text: 'horse'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author2])
 
-      comment1 = Comment.create!(text: "big and heavy", comment_author: comment_author1, blog_post: post1)
-      comment2 = Comment.create!(text: "big and wide", comment_author: comment_author1, blog_post: post1)
-      comment3 = Comment.create!(text: "big", comment_author: comment_author2, blog_post: post2)
-      comment4 = Comment.create!(text: "small", comment_author: comment_author2, blog_post: post2)
-      comment5 = Comment.create!(text: "big", comment_author: comment_author2, blog_post: post3)
-      comment6 = Comment.create!(text: "small", comment_author: comment_author2, blog_post: post4)
+  end
 
-      params = {
-        relation: BlogPost.all,
-        text: 'sick big dog paul',
-        fields: [
-          :title,
-          "description",
+  it "returns unique records even for has_many associations" do
+    params = {
+      relation: Author,
+      fields: [:name, {blog_posts: [:title], edited_posts: [:title]}],
+      text: 'author2'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author2])
 
-          comments: [
-            :text,
-            comment_author: [:name],
-          ],
-          editor: [:name],
-          author: [:name],
-        ]
-      }
-      expect( described_class.prepare(params).to_a ).to match_array([post1])
+    params[:fields] = [:name, {blog_posts: [:title], edited_posts: [:title]}]
+  end
 
-      params.merge!(text: 'sick dog author2')
-      expect( described_class.prepare(params).to_a ).to eq([])
+  it "suports searching same table via different associations" do
+    params = {
+      relation: BlogPost,
+      fields: [author: [:name], editor: [:name]],
+      text: 'author1'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post1, @post2, @post3, @post5])
 
-      params.merge!(text: 'author2')
-      expect( described_class.prepare(params).to_a ).to match_array([post3])
+    params[:text] = 'author2'
+    expect( described_class.prepare(params) ).to match_array([@post3])
+  end
 
-      params.merge!(text: 'author1')
-      expect( described_class.prepare(params).to_a ).to match_array([post1, post2, post3])
+  it "doesn't care about order of search associations" do
+    params = {
+      relation: BlogPost,
+      fields: [author: [:name], editor: [:name]],
+      text: 'author2'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post3])
 
-      post5 = BlogPost.create!(title: "sick horse that died", author: post_author1, deleted: true)
-      params = {
-        relation: Author,
-        text: 'Paul',
-        fields: [
-          :name,
-          replies: [
-            :text,
-            comment_author: [:name]
-          ],
-          profile: [:real_name],
-          blog_posts: [:title]
-        ]
-      }
-      expect( described_class.prepare(params).to_a ).to match_array([post_author1])
+    params[:fields] = [editor: [:name], author: [:name]]
+    expect( described_class.prepare(params) ).to match_array([@post3])
+  end
 
-      params.merge!(text: 'Big')
-      expect( described_class.prepare(params).to_a ).to match_array([post_author1, post_author2])
+  it "supports searching in associations with though option" do
+    params = {
+      relation: Author,
+      fields: [{replies: [:text]}],
+      text: 'wide'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author1])
+  end
 
-      params.merge!(text: 'classif')
-      expect( described_class.prepare(params).to_a ).to match_array([post_author2])
+  it "supports searching in deeply nested association columns" do
+    params = {
+      relation: Author,
+      fields: [edited_posts: [comments: [comment_author: [:name]]]],
+      text: 'john'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author1])
+  end
 
-      params.merge!(text: 'sick horse')
-      expect( described_class.prepare(params).to_a ).to match_array([post_author2])
+  it "supports associations with scopes" do
+    params = {
+      relation: Author,
+      fields: [{blog_posts: [:title]}],
+      text: 'horse'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post_author2])
+  end
 
-      BlogPost.delete_all # hack
-    end
+  it "can find record, even even when associated records doesn't exist" do
+    params = {
+      relation: BlogPost,
+      fields: [:title, editor: [:name], author: [:name]],
+      text: 'healty'
+    }
+    expect( described_class.prepare(params) ).to match_array([@post4])
+  end
 
-    context "when no collection passed" do
-      it "assigns resource class 'all' scope to collections" do
-        DatabaseCleaner.clean # hack due to this https://github.com/Casecommons/with_model/pull/18 (nested transactions)
+  it "assigns resource class 'all' scope to collections when no collection passed" do
+    params = {
+      text: 'foo',
+      fields: [],
+      relation: BlogPost
+    }
+    expect( described_class.prepare(params) ).to match_array BlogPost.all
+  end
 
-        BlogPost.create!(title: "sick dog")
-        expect( described_class.new(relation: BlogPost, text: '', fields: []).relation.to_sql ).to eq BlogPost.all.to_sql
+  it "use passed collection when collection passed" do
+    relation = BlogPost.where(title: "x")
+    params = {
+      relation: relation,
+      text: '',
+      fields: []
+    }
+    expect( described_class.prepare(params) ).to eq relation
+  end
 
-        params = {
-          text: '',
-          fields: [],
-          relation: BlogPost
-        }
-        expect( described_class.prepare(params).to_sql ).to eq BlogPost.all.to_sql
+  it "returns unmodified collection scope when no search fields given" do
+    relation = BlogPost.where(title: "x")
 
+    params = {
+      relation: relation,
+      text: 'text',
+      fields: []
+    }
+    expect( described_class.prepare(params)).to eq(relation)
+  end
 
-        BlogPost.delete_all # hack
-      end
-    end
+  it "returns unmodified collection scope when no text given" do
+    relation = BlogPost.where(title: "x")
 
-    context "when collection passed" do
-      it "use passed collection" do
-        relation = BlogPost.where(title: "x")
-        params = {
-          relation: relation,
-          text: '',
-          fields: []
-        }
-        expect( described_class.prepare(params) ).to eq relation
-      end
-    end
-
-    context "when no search or searchable fields given" do
-      it "returns unmodified collection scope" do
-        relation = BlogPost.where(title: "x")
-
-        params = {
-          relation: BlogPost.all,
-          text: 'text',
-          fields: []
-        }
-
-        expect( described_class.prepare(params).to_a ).to eq(relation.to_a)
-      end
-    end
+    params = {
+      relation: relation,
+      text: '',
+      fields: [:name]
+    }
+    expect( described_class.prepare(params)).to eq(relation)
   end
 
 end


### PR DESCRIPTION
When searching with resource finder in nested fields, if related object doesn't exist, matching record won't be returned.

This is because ResourceFinder is using inner join internally