### PR TITLE
Fix search when relation already has joins

### DIFF
--- a/releaf-core/app/lib/releaf/search.rb
+++ b/releaf-core/app/lib/releaf/search.rb
@@ -111,7 +111,8 @@ module Releaf
                      else
                        table1
                      end
-      source_table.join(table2, join_type).on(join_condition).join_sources
+      sql = source_table.join(table2, join_type).on(join_condition).join_sources.first.to_sql
+      Arel::Nodes::SqlLiteral.new(sql)
     end
   end
 end


### PR DESCRIPTION
It was possible to generate invalid SQL when relation already joins
table that will be joined by searcher and has where condition
referencing that table.

The table would have an alias added by rails/arel that would be hard to
predict, thus ruining ease of use.

P.S.
It seams that Rails 4.2 isn't affected