### PR TITLE
I18n: prevent default translation creation with `create_default: fals…

### DIFF
--- a/releaf-core/app/builders/releaf/builders/form_builder.rb
+++ b/releaf-core/app/builders/releaf/builders/form_builder.rb
@@ -579,11 +579,7 @@ class Releaf::Builders::FormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def translate_attribute(attribute)
-    t(attribute, scope: object_translation_scope)
-  end
-
-  def object_translation_scope
-    "activerecord.attributes.#{object.class.name.underscore}"
+    object.class.human_attribute_name(attribute, create_default: false)
   end
 
   def association_collection(reflector)

--- a/releaf-core/app/builders/releaf/builders/table_builder.rb
+++ b/releaf-core/app/builders/releaf/builders/table_builder.rb
@@ -74,7 +74,7 @@ class Releaf::Builders::TableBuilder
   def head_cell_content(column)
     unless column.to_sym == :toolbox
       attribute = column.to_s.gsub(".", "_")
-      t(attribute, scope: "activerecord.attributes.#{resource_class.name.underscore}")
+      resource_class.human_attribute_name(attribute, create_default: false)
     end
   end
 

--- a/releaf-core/spec/builders/builders/form_builder_spec.rb
+++ b/releaf-core/spec/builders/builders/form_builder_spec.rb
@@ -366,7 +366,7 @@ describe Releaf::Builders::FormBuilder, type: :class do
 
   describe "#label_text" do
     it "returns model attributes scoped translated value" do
-      allow(I18n).to receive(:t).with("color", scope: "activerecord.attributes.book").and_return("x")
+      allow(subject).to receive(:translate_attribute).with("color").and_return("x")
       expect(subject.label_text(:color)).to eq("x")
     end
 
@@ -388,8 +388,7 @@ describe Releaf::Builders::FormBuilder, type: :class do
     context "when :translation_key option exists" do
       context "when :translation_key is not blank" do
         it "passes :translation_key option to translation and return translated value" do
-          allow(subject).to receive(:object_translation_scope).and_return("xxxx")
-          allow(I18n).to receive(:t).with("true_color", scope: "xxxx").and_return("x")
+          allow(subject).to receive(:translate_attribute).with("true_color").and_return("x")
           expect(subject.label_text(:color, translation_key: "true_color")).to eq("x")
         end
       end
@@ -400,12 +399,6 @@ describe Releaf::Builders::FormBuilder, type: :class do
           expect(subject.label_text(:color, translation_key: "")).to eq("Color")
         end
       end
-    end
-  end
-
-  describe "#label_text" do
-    it "returns object translation scope `activerecord.attributes._object_class_`" do
-      expect(subject.object_translation_scope).to eq("activerecord.attributes.book")
     end
   end
 
@@ -562,8 +555,7 @@ describe Releaf::Builders::FormBuilder, type: :class do
 
   describe "#translate_attribute" do
     it "translates given attribute within object translation scope" do
-      allow(subject).to receive(:object_translation_scope).and_return("y")
-      allow(subject).to receive(:t).with("x", scope: "y").and_return("z")
+      allow(object.class).to receive(:human_attribute_name).with("x", create_default: false).and_return("z")
       expect(subject.translate_attribute("x")).to eq("z")
     end
   end

--- a/releaf-core/spec/builders/builders/table_builder_spec.rb
+++ b/releaf-core/spec/builders/builders/table_builder_spec.rb
@@ -200,12 +200,12 @@ describe Releaf::Builders::TableBuilder, type: :class do
 
   describe "#head_cell_content" do
     it "returns translated column scoped to resource class attributes" do
-      allow(subject).to receive(:t).with("some_long_name", scope: "activerecord.attributes.book").and_return("Taittls")
+      allow(resource_class).to receive(:human_attribute_name).with("some_long_name", create_default: false).and_return("Taittls")
       expect(subject.head_cell_content("some_long_name")).to eq('Taittls')
     end
 
     it "casts given column to string" do
-      allow(subject).to receive(:t).with("title", scope: "activerecord.attributes.book").and_return("Taittls")
+      allow(resource_class).to receive(:human_attribute_name).with("title", create_default: false).and_return("Taittls")
       expect(subject.head_cell_content(:title)).to eq('Taittls')
     end
 

--- a/releaf-i18n_database/lib/releaf/i18n_database/backend.rb
+++ b/releaf-i18n_database/lib/releaf/i18n_database/backend.rb
@@ -102,9 +102,17 @@ module Releaf
 
         # mark translation as missing
         CACHE[:missing][locale_key] = true
-        create_missing_translation(locale, key, options)
+        create_missing_translation(locale, key, options) if create_missing_translation?(options)
 
         return nil
+      end
+
+      def default(locale, object, subject, options = {})
+        if options[:create_default] == false
+          options = options.reject { |key, value| key == :create_default }
+          options[:create_missing] = false
+        end
+        super
       end
 
       def get_all_pluralizations
@@ -119,9 +127,11 @@ module Releaf
         keys.uniq
       end
 
-      def create_missing_translation(locale, key, options)
-        return if Releaf::I18nDatabase.create_missing_translations != true
+      def create_missing_translation?(options)
+        Releaf::I18nDatabase.create_missing_translations == true && options[:create_missing] != false
+      end
 
+      def create_missing_translation(locale, key, options)
         begin
           if options.has_key?(:count) && options[:create_plurals] == true
             get_all_pluralizations.each do|pluralization|


### PR DESCRIPTION
…e` option