### PR TITLE
Fix axlsx complaining about zip

### DIFF
--- a/releaf-core/releaf-core.gemspec
+++ b/releaf-core/releaf-core.gemspec
@@ -13,6 +13,11 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files = Dir["spec/**/*"]
 
+  # FIX axlsx complaining about missing zip/zip
+  s.add_dependency 'rubyzip', '>= 1.0.0'
+  s.add_dependency 'zip-zip'
+
+
   s.add_dependency 'rails', '~> 4.2.0'
   s.add_dependency 'i18n', '>= 0.7.0'
   s.add_dependency 'sass-rails'


### PR DESCRIPTION
This will fix the following error:

```
LoadError: cannot load such file -- zip/zip
/home/graudeejs/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
/home/graudeejs/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `block in require'
/home/graudeejs/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/graudeejs/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
/home/graudeejs/.rvm/gems/ruby-2.2.3/gems/axlsx-1.3.6/lib/axlsx.rb:26:in `<top (required)>'
```