### PR TITLE
Use newer mysql2 gem to fix mysql gem not being loaded error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gemspec
 
 case config["database"]["type"]
 when 'mysql'
-  gem 'mysql2', platform: :ruby
+  gem 'mysql2', '~> 0.3.18', platform: :ruby
   gem 'jdbc-mysql', platform: :jruby
   gem 'activerecord-jdbc-adapter', platform: :jruby
 when 'postgresql'


### PR DESCRIPTION
Generally this fixes releaf dummy only.

https://stackoverflow.com/questions/22932282/gemloaderror-specified-mysql2-for-database-adapter-but-the-gem-is-not-loade