### PR TITLE
Constrain axlsx-rails version to at least 0.3.0

### DIFF
--- a/releaf-core/releaf-core.gemspec
+++ b/releaf-core/releaf-core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'globalize-accessors'
   s.add_dependency 'nokogiri'
   s.add_dependency 'rack-cache'
-  s.add_dependency 'axlsx_rails'
+  s.add_dependency 'axlsx_rails', '>= 0.3.0'
   s.add_dependency 'roo'
 
   s.required_ruby_version = '>= 2.1.0'


### PR DESCRIPTION
In some cases 0.1.5 would get installed and device session controller
would fail to work with error similar to this:

```
NoMethodError:
  undefined method `call' for ActionController::Responder:Class
```

https://stackoverflow.com/questions/29461524/devise-authentication-error-with-actioncontrollerresponder-and-axlsx-rails-gem