### PR TITLE
releaf-core doens't require stringex

### DIFF
--- a/releaf-content/lib/releaf/content/engine.rb
+++ b/releaf-content/lib/releaf/content/engine.rb
@@ -1,4 +1,5 @@
 require 'awesome_nested_set'
+require 'stringex'
 
 module Releaf::Content
   require 'releaf/content/builders_autoload'

--- a/releaf-core/lib/releaf/core/engine.rb
+++ b/releaf-core/lib/releaf/core/engine.rb
@@ -1,7 +1,6 @@
 require 'gravatar_image_tag'
 require 'jquery-cookie-rails'
 require 'rails-settings-cached'
-require 'stringex'
 require 'ckeditor_rails'
 require 'will_paginate'
 require 'font-awesome-rails'


### PR DESCRIPTION
Move require statement to appropriate location.

Missed this one in one of my dev branches