### PR TITLE
Dry required ruby version

### DIFF
--- a/releaf-content/releaf-content.gemspec
+++ b/releaf-content/releaf-content.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'stringex'
   s.add_dependency 'awesome_nested_set'
 
-  s.required_ruby_version = '>= 2.2.0'
 end

--- a/releaf-i18n_database/releaf-i18n_database.gemspec
+++ b/releaf-i18n_database/releaf-i18n_database.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'axlsx_rails', '>= 0.3.0'
   s.add_dependency 'roo'
 
-  s.required_ruby_version = '>= 2.2.0'
 end

--- a/releaf-permissions/releaf-permissions.gemspec
+++ b/releaf-permissions/releaf-permissions.gemspec
@@ -16,5 +16,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'releaf-core', Releaf::VERSION
   s.add_dependency 'devise'
 
-  s.required_ruby_version = '>= 2.2.0'
 end


### PR DESCRIPTION
releaf-core is required by all releaf gems.
It's enough to set required ruby version in ruby-core gem.