### PR TITLE
WIP: Reduce query clutter

### DIFF
--- a/releaf-content/app/middleware/releaf/content/routes_reloader.rb
+++ b/releaf-content/app/middleware/releaf/content/routes_reloader.rb
@@ -6,8 +6,16 @@ module Releaf::Content
     end
 
     def call(env)
-      self.class.reload_if_expired
+      self.class.reload_if_expired unless asset_request?(env)
       @app.call(env)
+    end
+
+    def asset_request?(env)
+      env['PATH_INFO'].start_with?(asset_prefix)
+    end
+
+    def asset_prefix
+      @asset_prefix ||= Rails.configuration.assets[:prefix] + '/'
     end
 
     def self.routes_loaded

--- a/releaf-i18n_database/app/middleware/releaf/i18n_database/cache_reloader.rb
+++ b/releaf-i18n_database/app/middleware/releaf/i18n_database/cache_reloader.rb
@@ -1,0 +1,28 @@
+module Releaf::I18nDatabase
+  class CacheReloader
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      reload_if_expired unless asset_request?(env)
+      @app.call(env)
+    end
+
+    def asset_request?(env)
+      env['PATH_INFO'].start_with?(asset_prefix)
+    end
+
+    def asset_prefix
+      @asset_prefix ||= Rails.configuration.assets[:prefix] + '/'
+    end
+
+    def reload_if_expired
+      backend.reload_cache if backend.cache_expired?
+    end
+
+    def backend
+      I18n.backend
+    end
+  end
+end

--- a/releaf-i18n_database/lib/releaf/i18n_database/backend.rb
+++ b/releaf-i18n_database/lib/releaf/i18n_database/backend.rb
@@ -13,14 +13,12 @@ module Releaf
         CACHE[:updated_at] = self.class.translations_updated_at
       end
 
-      def reload_cache?
+      def cache_expired?
         CACHE[:updated_at] != self.class.translations_updated_at
       end
 
       def self.translations_updated_at
-        Rails.cache.fetch(UPDATED_AT_KEY, expires_in: 20.seconds) do
-          Releaf::Settings[UPDATED_AT_KEY]
-        end
+        Releaf::Settings[UPDATED_AT_KEY]
       end
 
       def self.translations_updated_at= value
@@ -81,8 +79,6 @@ module Releaf
 
       # Lookup translation from database
       def lookup(locale, key, scope = [], options = {})
-        # reload cache if cache timestamp differs from last translations update
-        reload_cache if reload_cache?
 
         key = normalize_flat_keys(locale, key, scope, options[:separator])
         locale_key = "#{locale}.#{key}"

--- a/releaf-i18n_database/lib/releaf/i18n_database/backend.rb
+++ b/releaf-i18n_database/lib/releaf/i18n_database/backend.rb
@@ -18,7 +18,9 @@ module Releaf
       end
 
       def self.translations_updated_at
-        Releaf::Settings[UPDATED_AT_KEY]
+        Rails.cache.fetch(UPDATED_AT_KEY, expires_in: 20.seconds) do
+          Releaf::Settings[UPDATED_AT_KEY]
+        end
       end
 
       def self.translations_updated_at= value

--- a/releaf-i18n_database/lib/releaf/i18n_database/engine.rb
+++ b/releaf-i18n_database/lib/releaf/i18n_database/engine.rb
@@ -17,6 +17,7 @@ module Releaf::I18nDatabase
 
   def self.initialize_component
     I18n.backend = Releaf::I18nDatabase::Backend.new
+    Rails.application.config.middleware.use Releaf::I18nDatabase::CacheReloader
   end
 
   def self.draw_component_routes router

--- a/releaf-i18n_database/spec/lib/i18n_database/backend_spec.rb
+++ b/releaf-i18n_database/spec/lib/i18n_database/backend_spec.rb
@@ -6,6 +6,7 @@ describe Releaf::I18nDatabase::Backend do
     allow( Releaf::I18nDatabase ).to receive(:create_missing_translations).and_return(true)
     allow( I18n.backend ).to receive(:reload_cache?).and_return(true)
     I18n.backend.reload_cache
+    Rails.cache.clear
   end
 
   describe "#store_translations" do

--- a/releaf-i18n_database/spec/middleware/cache_reloader_spec.rb
+++ b/releaf-i18n_database/spec/middleware/cache_reloader_spec.rb
@@ -1,0 +1,3 @@
+describe Releaf::I18nDatabase::CacheReloader do
+  pending "needs tests"
+end


### PR DESCRIPTION
## Before

Every asset request triggers checking if routes were updated
![2015 09 21_at_23 26 21](https://cloud.githubusercontent.com/assets/1020124/10004028/391c26ac-60b8-11e5-934f-2421dbd2e596.png)

Every single localization request triggers DB lookup weather cache need to be updated
![2015 09 21_at_23 05 00](https://cloud.githubusercontent.com/assets/1020124/10004037/437ae200-60b8-11e5-9943-c762f96d4a4c.png)

## After

Asses don't trigger routes update checking
![2015 09 21_at_23 19 23](https://cloud.githubusercontent.com/assets/1020124/10004086/8bd4230e-60b8-11e5-80ee-544adfcd3d54.png)

I18n tables aren't checked for updates for every localization request
![2015 09 21_at_23 32 24](https://cloud.githubusercontent.com/assets/1020124/10004183/17107436-60b9-11e5-92a4-ccae1d230a65.png)


This truly helps during development, these requests clutter rails log a lot.