### PR TITLE
Simplify syntax for frontend routes drawing

### DIFF
--- a/releaf-content/lib/releaf-content.rb
+++ b/releaf-content/lib/releaf-content.rb
@@ -1,3 +1,5 @@
+require 'releaf/content/router_proxy'
+require 'releaf/content/node_mapper'
 require 'releaf/content/engine'
 require 'releaf/content/acts_as_node'
 require 'releaf/content/node'

--- a/releaf-content/lib/releaf/content/engine.rb
+++ b/releaf-content/lib/releaf/content/engine.rb
@@ -33,4 +33,8 @@ module Releaf::Content
       end
     end
   end
+
+  ActiveSupport.on_load :action_controller do
+    ActionDispatch::Routing::Mapper.send(:include, Releaf::Content::NodeMapper)
+  end
 end

--- a/releaf-content/lib/releaf/content/node_mapper.rb
+++ b/releaf-content/lib/releaf/content/node_mapper.rb
@@ -1,0 +1,19 @@
+module Releaf::Content
+  module NodeMapper
+    def releaf_routes_for(node_class, controller: default_controller(node_class), &block)
+      Releaf::Content::Route.for(node_class, controller).each do |route|
+        Releaf::Content::RouterProxy.new(self, route).draw(&block)
+      end
+    end
+
+    private
+
+    def default_controller(node_class)
+      if node_class.is_a? ActionController::Base
+        node_class.name.underscore.sub(/controller$/, '')
+      else
+        node_class.name.pluralize.underscore
+      end
+    end
+  end
+end

--- a/releaf-content/lib/releaf/content/route.rb
+++ b/releaf-content/lib/releaf/content/route.rb
@@ -1,6 +1,6 @@
 module Releaf::Content
   class Route
-    attr_accessor :path, :node, :locale, :node_id
+    attr_accessor :path, :node, :locale, :node_id, :default_controller
 
     def self.node_class
       # TODO model should be configurable
@@ -9,54 +9,87 @@ module Releaf::Content
 
     # Return node route params which can be used in Rails route options
     #
-    # @param controller_action [String] optional string with action and controller for route (Ex. home#index)
-    # @param args [Hash] options to merge with internally built params. Passed params overrides route params.
+    # @param method_or_path [String] string with action and controller for route (Ex. home#index)
+    # @param options [Hash] options to merge with internally built params. Passed params overrides route params.
     # @return [Hash] route options. Will return at least node "node_id" and "locale" keys.
-    def params(controller_action, args = {})
-      route_params = {
-        node_id: node_id.to_s,
-        locale: locale
-      }
+    def params(*args)
+      only_hash = args.first.is_a?(Hash)
 
-      if controller_action.is_a? Hash
-        args = controller_action.merge(args)
-        controller_action = nil
+      if only_hash
+        options = args.first.dup
+      else
+        method_or_path = args[0].to_s
+        options = args[1].try!(:dup) || {}
+        action_path = path_for(method_or_path, options)
+        options[:to] = controller_and_action_for(method_or_path, options)
       end
 
-      route_params.merge!(args)
+      route_options = options.merge({
+        node_id: node_id.to_s,
+        locale: locale,
+      })
 
       # normalize as with locale
-      if locale.present? && route_params[:as].present?
-        route_params[:as] = "#{locale}_#{route_params[:as]}"
+      if locale.present? && route_options[:as].present?
+        route_options[:as] = "#{locale}_#{route_options[:as]}"
       end
 
-      route_params[path] = controller_action if controller_action.present?
-
-      route_params
+      if only_hash
+        route_options
+      else
+        [action_path, route_options]
+      end
     end
 
     # Return routes for given class that implement ActsAsNode
     #
-    # @param content_type [Class] content type to load related nodes
+    # @param class_name [Class] class name to load related nodes
+    # @param default_controller [String]
     # @return [Array] array of Content::Route objects
-    def self.for(content_type)
-      begin
-        node_class.where(content_type: content_type).each.inject([]) do |routes, node|
-          routes << build_route_object(node) if node.available?
-          routes
-        end
-      rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
-        []
+    def self.for(content_type, default_controller)
+      node_class.where(content_type: content_type).each.inject([]) do |routes, node|
+        routes << build_route_object(node, default_controller) if node.available?
+        routes
       end
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+      []
     end
 
     # Build Content::Route from Node object
-    def self.build_route_object node
+    def self.build_route_object(node, default_controller)
       route = new
       route.node_id = node.id.to_s
       route.path = node.url
       route.locale = node.root.locale
+      route.default_controller = default_controller
+
       route
+    end
+
+    private
+
+    def path_for(method_or_path, options)
+      if method_or_path.include?('#')
+        path
+      elsif options.key?(:to)
+        "#{path}/#{method_or_path}"
+      else
+        path
+      end
+    end
+
+    def controller_and_action_for(method_or_path, options)
+      if method_or_path.start_with?('#')
+        "#{default_controller}#{method_or_path}"
+      elsif method_or_path.include?('#')
+        method_or_path
+      elsif options[:to].try!(:start_with?, '#')
+        "#{default_controller}#{options[:to]}"
+      elsif options[:to].try!(:include?, '#')
+        options[:to]
+      else
+        "#{default_controller}##{method_or_path}"
+      end
     end
 
   end

--- a/releaf-content/lib/releaf/content/route.rb
+++ b/releaf-content/lib/releaf/content/route.rb
@@ -12,17 +12,10 @@ module Releaf::Content
     # @param method_or_path [String] string with action and controller for route (Ex. home#index)
     # @param options [Hash] options to merge with internally built params. Passed params overrides route params.
     # @return [Hash] route options. Will return at least node "node_id" and "locale" keys.
-    def params(*args)
-      only_hash = args.first.is_a?(Hash)
-
-      if only_hash
-        options = args.first.dup
-      else
-        method_or_path = args[0].to_s
-        options = args[1].try!(:dup) || {}
-        action_path = path_for(method_or_path, options)
-        options[:to] = controller_and_action_for(method_or_path, options)
-      end
+    def params(method_or_path, options = {})
+      method_or_path = method_or_path.to_s
+      action_path = path_for(method_or_path, options)
+      options[:to] = controller_and_action_for(method_or_path, options)
 
       route_options = options.merge({
         node_id: node_id.to_s,
@@ -34,11 +27,7 @@ module Releaf::Content
         route_options[:as] = "#{locale}_#{route_options[:as]}"
       end
 
-      if only_hash
-        route_options
-      else
-        [action_path, route_options]
-      end
+      [action_path, route_options]
     end
 
     # Return routes for given class that implement ActsAsNode

--- a/releaf-content/lib/releaf/content/router_proxy.rb
+++ b/releaf-content/lib/releaf/content/router_proxy.rb
@@ -1,0 +1,23 @@
+module Releaf::Content
+  class RouterProxy
+    attr_accessor :router, :releaf_route
+
+    def initialize(router, releaf_route)
+      self.router = router
+      self.releaf_route = releaf_route
+    end
+
+    def draw(&block)
+      instance_exec(releaf_route, &block)
+    end
+
+    def method_missing(method_name, *args, &block)
+      if router.respond_to?(method_name)
+        router.public_send(method_name, *releaf_route.params(*args), &block)
+      else
+        super
+      end
+    end
+  end
+
+end

--- a/releaf-content/spec/lib/releaf/content/route_spec.rb
+++ b/releaf-content/spec/lib/releaf/content/route_spec.rb
@@ -49,20 +49,8 @@ describe Releaf::Content::Route do
   end
 
   describe '#params' do
-    specify do # TODO test title
+    it "returns params for router method" do
       expect(node_route.params("home#index")).to eq ['/en', {:node_id=>"12", :locale=>"en", :to=>"home#index"}]
-    end
-
-    context "when hash given as first argument" do
-
-      it "adds node_id and locale options" do
-        expect(node_route.params('en/search' => 'home#search')).to eq({
-          'en/search' => 'home#search',
-          node_id: "12",
-          locale: "en"
-        })
-      end
-
     end
 
     context "when :as given in args" do

--- a/releaf-content/spec/lib/releaf/content/route_spec.rb
+++ b/releaf-content/spec/lib/releaf/content/route_spec.rb
@@ -15,26 +15,26 @@ describe Releaf::Content::Route do
     end
 
     it "returns an array" do
-      expect(described_class.for(HomePage).class).to eq(Array)
+      expect(described_class.for(HomePage, 'foo').class).to eq(Array)
     end
 
     context "when databse doesn't exists" do
       it "returns an empty array" do
         allow(described_class.node_class).to receive(:where).and_raise(ActiveRecord::NoDatabaseError.new("xxx"))
-        expect(described_class.for(HomePage)).to eq([])
+        expect(described_class.for(HomePage, 'foo')).to eq([])
       end
     end
 
     context "when releaf_nodes table doesn't exists" do
       it "returns an empty array" do
         allow(described_class.node_class).to receive(:where).and_raise(ActiveRecord::StatementInvalid.new("xxx"))
-        expect(described_class.for(HomePage)).to eq([])
+        expect(described_class.for(HomePage, 'foo')).to eq([])
       end
     end
 
     context "when releaf_nodes table exists" do
       it "returns an array of Node::Route objects" do
-        result = described_class.for(HomePage)
+        result = described_class.for(HomePage, 'foo')
         expect(result.count).to eq(1)
         expect(result.first.class).to eq(described_class)
       end
@@ -42,37 +42,25 @@ describe Releaf::Content::Route do
       context "when node is not available" do
         it "does not include it in return" do
           allow_any_instance_of(Node).to receive(:available?).and_return(false)
-          expect(described_class.for(HomePage)).to eq([])
+          expect(described_class.for(HomePage, 'foo')).to eq([])
         end
       end
     end
   end
 
   describe '#params' do
-    it "returns a hash with node_id" do
-      expect(node_route.params("home#index")[:node_id]).to eq('12')
-    end
-
-    it "returns a hash with locale" do
-      expect(node_route.params("home#index")[:locale]).to eq("en")
-    end
-
-    it "returns a hash with path" do
-      expect(node_route.params("home#index")["/en"]).to eq("home#index")
-    end
-
-    it "merges passed args into the returned hash" do
-      expect(node_route.params("home#index", locale: "de")[:locale]).to eq("de")
+    specify do # TODO test title
+      expect(node_route.params("home#index")).to eq ['/en', {:node_id=>"12", :locale=>"en", :to=>"home#index"}]
     end
 
     context "when hash given as first argument" do
 
-      it "uses it for args" do
-        expect(node_route.params('en/search' => 'home#search')['en/search']).to eq('home#search')
-      end
-
-      it "does not set default path in hash" do
-        expect(node_route.params('en/search' => 'home#search')).to_not have_key('en/')
+      it "adds node_id and locale options" do
+        expect(node_route.params('en/search' => 'home#search')).to eq({
+          'en/search' => 'home#search',
+          node_id: "12",
+          locale: "en"
+        })
       end
 
     end
@@ -80,14 +68,14 @@ describe Releaf::Content::Route do
     context "when :as given in args" do
       context "when node has a locale" do
         it "prepends locale to :as" do
-          expect(node_route.params("home#index", as: "home")[:as]).to eq("en_home")
+          expect(node_route.params("home#index", as: "home").last).to match hash_including(as: "en_home")
         end
       end
 
       context "when node does not have a locale" do
-        it "uses :as as passed" do
+        it "doesn't modify :as option" do
           node_route.locale = nil
-          expect(node_route.params("home#index", as: "home")[:as]).to eq("home")
+          expect(node_route.params("home#index", as: "home").last).to match hash_including(as: "home")
         end
       end
     end

--- a/releaf-content/spec/routing/node_mapper_spec.rb
+++ b/releaf-content/spec/routing/node_mapper_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+describe Releaf::Content::NodeMapper do
+  after(:all) do
+    # reset dummy app routes
+    Dummy::Application.reload_routes!
+  end
+
+  before do
+    Dummy::Application.reload_routes!
+    @text_page = FactoryGirl.create(:text_page)
+    @lv_root = create(:home_page_node, name: "lv", locale: "lv", slug: 'lv')
+    @node = FactoryGirl.create(:node, slug: 'test-page', content: @text_page, parent: @lv_root)
+  end
+
+  describe "#releaf_routes_for" do
+
+    describe "using current node path" do
+      example "using default controller " do
+        routes.draw do
+          releaf_routes_for(TextPage) do |route|
+            get 'show'
+            delete :destroy
+          end
+        end
+
+        expect(get: '/lv/test-page').to route_to(
+          "controller" => "text_pages",
+          "action" => "show",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv'
+        )
+
+        expect(delete: '/lv/test-page').to route_to(
+          "controller" => "text_pages",
+          "action" => "destroy",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv'
+        )
+      end
+
+      example "overriding default controller" do
+        routes.draw do
+          releaf_routes_for(TextPage, controller: 'home_pages') do |route|
+            get 'show'
+            delete :destroy
+          end
+        end
+
+        expect(get: '/lv/test-page').to route_to(
+          "controller" => "home_pages",
+          "action" => "show",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv'
+        )
+      end
+
+      example "specifying different than default controller for route" do
+        routes.draw do
+          releaf_routes_for(TextPage, controller: 'doesnt_matter') do |route|
+            get 'home_pages#hide'
+          end
+        end
+
+        expect(get: '/lv/test-page').to route_to(
+          "controller" => "home_pages",
+          "action" => "hide",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv'
+        )
+      end
+    end
+
+    describe "adding uri parts to node path" do
+      example "speciffying custom controller and action" do
+        routes.draw do
+          releaf_routes_for(TextPage) do |route|
+            get ':my_id/list', to: 'home_pages#list'
+          end
+        end
+
+        expect(get: '/lv/test-page/8888/list').to route_to(
+          "controller" => "home_pages",
+          "action" => "list",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv',
+          "my_id" => '8888'
+        )
+      end
+
+      example "speciffying action" do
+        routes.draw do
+          releaf_routes_for(TextPage) do |route|
+            get ':my_id/list', to: '#list'
+          end
+        end
+
+        expect(get: '/lv/test-page/8888/list').to route_to(
+          "controller" => "text_pages",
+          "action" => "list",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv',
+          "my_id" => '8888'
+        )
+      end
+
+      example "speciffying action and overriding default controller" do
+        routes.draw do
+          releaf_routes_for(TextPage, controller: 'home_pages') do |route|
+            get ':my_id/list', to: '#list'
+          end
+        end
+
+        expect(get: '/lv/test-page/8888/list').to route_to(
+          "controller" => "home_pages",
+          "action" => "list",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv',
+          "my_id" => '8888'
+        )
+      end
+
+      example "speciffying custom path" do
+        routes.draw do
+          releaf_routes_for(TextPage) do |route|
+            get 'home_pages#show', path: "#{route.path}/abc/:my_id"
+          end
+        end
+
+        expect(get: '/lv/test-page/abc/333').to route_to(
+          "controller" => "home_pages",
+          "action" => "show",
+          "node_id" => @node.id.to_s,
+          "locale" => 'lv',
+          "my_id" => '333'
+        )
+      end
+
+    end
+
+  end
+end

--- a/releaf-core/lib/generators/dummy/templates/config/routes.rb
+++ b/releaf-core/lib/generators/dummy/templates/config/routes.rb
@@ -3,16 +3,16 @@ Dummy::Application.routes.draw do
     releaf_resources :books, :authors, :chapters, :publishers
   end
 
-  Releaf::Content::Route.for(HomePage).each do|route|
-    get route.params('home_pages#show')
+  releaf_routes_for(HomePage) do
+    get 'show'
   end
 
-  Releaf::Content::Route.for(TextPage).each do|route|
-    get route.params('text_pages#show')
+  releaf_routes_for(TextPage) do
+    get 'show'
   end
 
-  Releaf::Content::Route.for(ContactsController).each do|route|
-    get route.params('contacts#show')
+  releaf_routes_for(ContactsController) do
+    get 'show'
   end
 
   root to: 'application#redirect_to_locale_root'


### PR DESCRIPTION
Here's a small abstraction which I think improves routes readability and usability (i.e. pimplier syntax)

Before:
```ruby
Releaf::Content::Route.for(HomePage).each do |route|
  get route.params('home_pages#show')
end
```

After:
```ruby
releaf_route_for(HomePage) do
  get 'show'
end
```

You can also customize path like this:
```ruby
releaf_route_for(HomePage) do |route|
  get 'home_pages#show', path: "#{route.path}/custom"
end
```
Route argument is an instance of ```Releaf::Content::Route```

Note: this change is even backwards compatible :)

I'd like to hear feedback from @miks, @guntis prior writing tests.