### PR TITLE
Fix case when profile controller is inherited and used different resource_class

### DIFF
--- a/releaf-permissions/app/controllers/releaf/permissions/profile_controller.rb
+++ b/releaf-permissions/app/controllers/releaf/permissions/profile_controller.rb
@@ -46,7 +46,7 @@ module Releaf::Permissions
       }
 
       # use already loaded admin user instance
-      @resource = access_control.user
+      @resource = access_control.user.becomes(resource_class)
     end
 
     def permitted_params

--- a/releaf-permissions/spec/controllers/permissions/profile_controller_spec.rb
+++ b/releaf-permissions/spec/controllers/permissions/profile_controller_spec.rb
@@ -26,6 +26,11 @@ describe Releaf::Permissions::ProfileController do
           "email" => "new.email@example.com",
           "locale" => "lv"
         }
+
+        # This is needed in order to get same instance as we expect.
+        # Otherwise we'll get same record, but different instance and test will fail
+        allow( user ).to receive(:becomes).with(Releaf::Permissions::User).and_return(user)
+
         expect(user).to receive(:update_attributes).with(attributes)
         patch :update, {resource: attributes}
       end


### PR DESCRIPTION
When controller then extends profile controller sets resource class to
use sublcass of Releaf::Permissions::User, it's actually not being used,
because @resource is set in #setup to current user.

To fix this, we specifically say which class we want to work with by
using #becomes.

After this change if you add some custom validation to subclass of
Releaf::Permissions::User and override .resource_class to return it.
It will actually run these additional validations.