### PR TITLE
Fix Sprockets::Rails::Helper::AssetNotPrecompiled exception

### DIFF
--- a/releaf-core/lib/releaf/core/engine.rb
+++ b/releaf-core/lib/releaf/core/engine.rb
@@ -26,6 +26,7 @@ module Releaf::Core
   class Engine < ::Rails::Engine
     initializer 'precompile', group: :all do |app|
       app.config.assets.precompile += %w(ckeditor/*)
+      app.config.assets.precompile += %w(releaf/icons/*)
     end
   end
 


### PR DESCRIPTION
![error](https://cloud.githubusercontent.com/assets/1020124/11931885/d492694c-a7f9-11e5-8f9f-1b9f70470958.png)

Error above happens when you visit admin page in fresh dummy app.