### PR TITLE
Fix releaf-core when not using "releaf" gem, to include all gems

### DIFF
--- a/releaf-core/lib/releaf/core/engine.rb
+++ b/releaf-core/lib/releaf/core/engine.rb
@@ -30,7 +30,5 @@ module Releaf::Core
     end
   end
 
-  ActiveSupport.on_load :action_controller do
-    ActionDispatch::Routing::Mapper.send(:include, Releaf::Core::RouteMapper)
-  end
+  ActionDispatch::Routing::Mapper.send(:include, Releaf::Core::RouteMapper)
 end


### PR DESCRIPTION
Problem description:
When using only **releaf-core** and **releaf-permissions** gems, running ```rails s``` will fail with NoMethodError, compaining about ```mount_releaf_at```

This patch seams to fix the issue. Maybe there is better solution to this problem.