### PR TITLE
Add support for mounting releaf under subdomain

### DIFF
--- a/releaf-core/lib/releaf/root/default_controller_resolver.rb
+++ b/releaf-core/lib/releaf/root/default_controller_resolver.rb
@@ -14,11 +14,28 @@ module Releaf::Root
     end
 
     def controller_index_exists?(controller_name)
-      Rails.application.routes.routes.map{|route| route.defaults}.include?(controller: controller_name, action: "index")
+      route_options = { controller: controller_name, action: "index" }
+      if subdomain.present?
+        # If subdomain is present try to find route matching it
+        # since it'll be most specific route
+        subdomain_route_options = route_options.merge(subdomain: subdomain)
+        return true if route_defaults.include?(subdomain_route_options)
+      end
+      route_defaults.include?(route_options)
     end
 
     def controllers
       Releaf.application.config.available_controllers
+    end
+
+    private
+
+    def route_defaults
+      @route_defaults ||= Rails.application.routes.routes.map(&:defaults)
+    end
+
+    def subdomain
+      current_controller.request.subdomain
     end
   end
 end

--- a/releaf-core/spec/lib/releaf/root/default_controller_resolver_spec.rb
+++ b/releaf-core/spec/lib/releaf/root/default_controller_resolver_spec.rb
@@ -1,7 +1,14 @@
 require "rails_helper"
 
 describe Releaf::Root::DefaultControllerResolver do
-  subject{ described_class.new(current_controller: Releaf::RootController.new) }
+  let(:controller) { Releaf::RootController.new }
+  let(:request) { instance_double(ActionDispatch::Request, subdomain: nil) }
+  subject { described_class.new(current_controller: controller) }
+
+  before do
+    allow( controller ).to receive(:request).and_return(request)
+  end
+
   it_behaves_like "an Releaf::Service includer"
 
   describe "#call" do


### PR DESCRIPTION
Given Releaf was mounted like this:
```ruby
  mount_releaf_at '/admin' do
    releaf_resources :posts
  end
```

This patch allows mounting releaf under subdomain (such as *admin.example.com*) like this
```ruby
  constraints subdomain: 'admin' do
    mount_releaf_at '/' do
      namespace :admin, path: '/' do
         releaf_resources :posts
      end
    end
  end
```
without any other modification to existing code.

NOTE: Here I added namespace just to have my admin controller namespaced and separated from public controllers. That is entirely optional.