### PR TITLE
Fix releaf by locking max version of rails-settings-cached

### DIFF
--- a/releaf-core/releaf-core.gemspec
+++ b/releaf-core/releaf-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties'
   s.add_dependency 'haml-rails'
   s.add_dependency 'dragonfly'
-  s.add_dependency 'rails-settings-cached', '>= 0.4.5'
+  s.add_dependency 'rails-settings-cached', '>= 0.4.5', '< 0.6.0'
   s.add_dependency 'ckeditor_rails'
   s.add_dependency 'acts_as_list'
   s.add_dependency 'will_paginate'


### PR DESCRIPTION
rails-settings-cached has braking changes:
https://github.com/huacnlee/rails-settings-cached/blob/master/CHANGELOG.md

I only verified that latest version doesn't work and that versions below 0.6.0 work fine.

This is a quick fix, Someone should update releaf to work with rails-settings-cached newest versions.