### PR TITLE
Duplicate dragonfly files

### DIFF
--- a/releaf-content/app/services/releaf/content/node/copy.rb
+++ b/releaf-content/app/services/releaf/content/node/copy.rb
@@ -50,10 +50,14 @@ module Releaf
       def duplicate_content_dragonfly_attributes(new_content)
         content_dragonfly_attributes.each do |attribute_name|
           accessor_name = attribute_name.gsub("_uid", "")
-          begin
-            dragonfly_attachment = node.content.send(accessor_name) if node.content.send(accessor_name).path
-          rescue
-            dragonfly_attachment = nil
+          dragonfly_attachment = node.content.send(accessor_name)
+
+          if dragonfly_attachment.present?
+            begin
+              dragonfly_attachment.path  # verify that the file exists
+            rescue Dragonfly::Job::Fetch::NotFound
+              dragonfly_attachment = nil
+            end
           end
 
           new_content.send("#{attribute_name}=", nil)

--- a/releaf-content/app/services/releaf/content/node/copy.rb
+++ b/releaf-content/app/services/releaf/content/node/copy.rb
@@ -40,8 +40,9 @@ module Releaf
       def duplicate_content
         return if node.content_id.blank?
 
-        new_content = node.content.dup
+        new_content = node.content.class.new(node.content.attributes.reject{ |k, v| content_dragonfly_attributes.push("id").include?(k) })
         duplicate_content_dragonfly_attributes(new_content)
+
         new_content.save!
         new_content
       end

--- a/releaf-content/app/services/releaf/content/node/copy.rb
+++ b/releaf-content/app/services/releaf/content/node/copy.rb
@@ -47,10 +47,16 @@ module Releaf
       end
 
       def duplicate_content_dragonfly_attributes(new_content)
-        content_dragonfly_attributes.each do|attribute_name|
+        content_dragonfly_attributes.each do |attribute_name|
           accessor_name = attribute_name.gsub("_uid", "")
+          begin
+            dragonfly_attachment = node.content.send(accessor_name) if node.content.send(accessor_name).path
+          rescue
+            dragonfly_attachment = nil
+          end
+
           new_content.send("#{attribute_name}=", nil)
-          new_content.send("#{accessor_name}=", node.content.send(accessor_name))
+          new_content.send("#{accessor_name}=", dragonfly_attachment)
         end
       end
 

--- a/releaf-content/app/services/releaf/content/node/copy.rb
+++ b/releaf-content/app/services/releaf/content/node/copy.rb
@@ -40,11 +40,16 @@ module Releaf
       def duplicate_content
         return if node.content_id.blank?
 
-        new_content = node.content.class.new(node.content.attributes.reject{ |k, v| content_dragonfly_attributes.push("id").include?(k) })
+        new_content = node.content.class.new(cloned_content_attributes)
         duplicate_content_dragonfly_attributes(new_content)
 
         new_content.save!
         new_content
+      end
+
+      def cloned_content_attributes
+        skippable_attribute_names = ["id"] + content_dragonfly_attributes
+        node.content.attributes.except(*skippable_attribute_names)
       end
 
       def duplicate_content_dragonfly_attributes(new_content)

--- a/releaf-content/spec/services/releaf/content/node/copy_spec.rb
+++ b/releaf-content/spec/services/releaf/content/node/copy_spec.rb
@@ -61,7 +61,6 @@ describe Releaf::Content::Node::Copy do
         old_content = HomePage.new(banner_uid: "yy")
         new_content = HomePage.new()
         node.content = old_content
-        allow(old_content).to receive(:banner).and_return("a")
 
         expect(new_content).to receive(:banner=).with(nil)
         expect(new_content).to receive(:banner_uid=).with(nil)

--- a/releaf-content/spec/services/releaf/content/node/copy_spec.rb
+++ b/releaf-content/spec/services/releaf/content/node/copy_spec.rb
@@ -23,14 +23,14 @@ describe Releaf::Content::Node::Copy do
       it "returns saved duplicated content" do
         content = HomePage.new
         expect( content ).to receive(:save!)
-        expect( node.content ).to receive(:dup).and_return(content)
+        expect( node.content.class ).to receive(:new).and_return(content)
         expect( subject.duplicate_content ).to eq content
       end
 
       it "reassigns dragonfly accessors" do
         content = HomePage.new
         expect( content ).to receive(:save!)
-        allow( node.content ).to receive(:dup).and_return(content)
+        allow( node.content.class ).to receive(:new).and_return(content)
         expect( subject ).to receive(:duplicate_content_dragonfly_attributes).with(content)
         expect( subject.duplicate_content ).to eq content
       end

--- a/releaf-content/spec/services/releaf/content/node/copy_spec.rb
+++ b/releaf-content/spec/services/releaf/content/node/copy_spec.rb
@@ -44,15 +44,29 @@ describe Releaf::Content::Node::Copy do
   end
 
   describe "#duplicate_content_dragonfly_attributes" do
-    it "reassigns dragonfly accessors to given content instance from node content" do
-      old_content = HomePage.new(banner_uid: "yy")
-      new_content = HomePage.new(banner_uid: "xx")
-      node.content = old_content
-      allow(old_content).to receive(:banner).and_return("a")
+    context "when dragonfly file is present" do
+      it "reassigns dragonfly accessors to given content instance from node content" do
+        old_content = HomePage.create(banner: File.new("releaf-core/spec/fixtures/cs.png"))
+        new_content = HomePage.new()
+        node.content = old_content
 
-      expect(new_content).to receive(:banner=).with("a")
-      expect(new_content).to receive(:banner_uid=).with(nil)
-      subject.duplicate_content_dragonfly_attributes(new_content)
+        expect(new_content).to receive(:banner=).with(old_content.banner)
+        expect(new_content).to receive(:banner_uid=).with(nil)
+        subject.duplicate_content_dragonfly_attributes(new_content)
+      end
+    end
+
+    context "when dragonfly file is not present" do
+      it "doesn't reassigns dragonfly accessors to given content instance from node content" do
+        old_content = HomePage.new(banner_uid: "yy")
+        new_content = HomePage.new()
+        node.content = old_content
+        allow(old_content).to receive(:banner).and_return("a")
+
+        expect(new_content).to receive(:banner=).with(nil)
+        expect(new_content).to receive(:banner_uid=).with(nil)
+        subject.duplicate_content_dragonfly_attributes(new_content)
+      end
     end
   end
 

--- a/releaf-content/spec/services/releaf/content/node/copy_spec.rb
+++ b/releaf-content/spec/services/releaf/content/node/copy_spec.rb
@@ -45,7 +45,9 @@ describe Releaf::Content::Node::Copy do
 
   describe "#cloned_content_attributes" do
     it "returns attributes without id and dragonfly attributes" do
-      node.content = HomePage.new(id: 42, banner_uid: "re")
+      node.content = HomePage.new(id: 42, banner_uid: "re", intro_text_html: "some text")
+
+      expect(subject.cloned_content_attributes).to have_key("intro_text_html")
       expect(subject.cloned_content_attributes).not_to include(:id, :banner_uid)
     end
   end

--- a/releaf-content/spec/services/releaf/content/node/copy_spec.rb
+++ b/releaf-content/spec/services/releaf/content/node/copy_spec.rb
@@ -43,6 +43,13 @@ describe Releaf::Content::Node::Copy do
     end
   end
 
+  describe "#cloned_content_attributes" do
+    it "returns attributes without id and dragonfly attributes" do
+      node.content = HomePage.new(id: 42, banner_uid: "re")
+      expect(subject.cloned_content_attributes).not_to include(:id, :banner_uid)
+    end
+  end
+
   describe "#duplicate_content_dragonfly_attributes" do
     context "when dragonfly file is present" do
       it "reassigns dragonfly accessors to given content instance from node content" do


### PR DESCRIPTION
Due to this https://groups.google.com/forum/#!topic/dragonfly-users/lUp3udF59dI
one needs to create new instance instead of dup, in order to prevent dragonfly deleting attachment for original object.