### PR TITLE
Travis: Try to use latest Rubygems, Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
   - gem install specific_install
-  - gem specific_install bundler/bundler # gem i bundler
+  - gem specific_install https://github.com/bundler/bundler.git
   - gem update --system
   - 'cp "config.yml.${DB}.travis" "config.yml"'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ matrix:
     - env: DB=pg
 
 before_install:
-  - gem i bundler
+  - gem install specific_install
+  - gem specific_install bundler/bundler # gem i bundler
   - gem update --system
   - 'cp "config.yml.${DB}.travis" "config.yml"'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
     - env: DB=pg
 
 before_install:
+  - gem i bundler
+  - gem update --system
   - 'cp "config.yml.${DB}.travis" "config.yml"'
 
 before_script:


### PR DESCRIPTION
This PR tries to use latest Rubygems and Bundler to see the output in Travis.

It's a WIP.

- Hm, with `specific_install` + Bundler from master branch, it could be a thing. TIL: `gem specific_install ...` is aliased as `gem git_install ...`