### PR TITLE
Newer ckeditor version doesn't return CKEditorFuncNum value

### DIFF
--- a/releaf-core/app/assets/javascripts/releaf/include/field.type_richtext.js
+++ b/releaf-core/app/assets/javascripts/releaf/include/field.type_richtext.js
@@ -78,7 +78,7 @@ jQuery(function()
 
         config.width = '100%';
         config.height = textarea.outerHeight();
-        config.filebrowserUploadMethod = "form"
+        config.filebrowserUploadMethod = 'form';
 
         if( !textarea.attr( 'id' ) )
         {

--- a/releaf-core/app/assets/javascripts/releaf/include/field.type_richtext.js
+++ b/releaf-core/app/assets/javascripts/releaf/include/field.type_richtext.js
@@ -78,6 +78,7 @@ jQuery(function()
 
         config.width = '100%';
         config.height = textarea.outerHeight();
+        config.filebrowserUploadMethod = "form"
 
         if( !textarea.attr( 'id' ) )
         {


### PR DESCRIPTION
This bug doesn't allow file uploading for richtext fields, as this parameter is missing.
As from version 4.9 ckeditor expects response in json, or config.filebrowserUploadMethod must be set to form, as in this fix.

https://docs.ckeditor.com/ckeditor4/latest/guide/dev_file_upload.html#response-file-uploaded-successfully

https://stackoverflow.com/questions/49390242/how-to-return-ckeditorfuncnum